### PR TITLE
Communicating state from multiprocessing workers to the main process

### DIFF
--- a/torchdata/dataloader2/communication/map.py
+++ b/torchdata/dataloader2/communication/map.py
@@ -183,3 +183,12 @@ class QueueWrapperForMap(NonBlockingMap):
         except communication.protocol.EmptyQueue:
             raise NotAvailable
         return response.len
+
+    def state_dict(self):
+        if self.protocol.can_take_request():
+            self.protocol.request_state()
+        try:
+            response = self.protocol.get_response_state(block=True, timeout=self._response_wait_time)
+        except communication.protocol.EmptyQueue:
+            raise NotAvailable
+        return response.value

--- a/torchdata/dataloader2/communication/messages.py
+++ b/torchdata/dataloader2/communication/messages.py
@@ -103,6 +103,17 @@ class StopIterationResponse(Response):
     pass
 
 
+class GetStateRequest(Request):
+    pass
+
+
+class GetStateResponse(Request):
+    __slots__ = "value"
+
+    def __init__(self, value):
+        self.value = value
+
+
 class InvalidStateResponse(Response):
     """
     Returned by DataPipe when it is expecting to get reset request,

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -376,6 +376,22 @@ class MultiProcessingReadingService(ReadingServiceInterface):
         self._worker_processes = []
         self._dispatch_process = None
 
+    def snapshot(self):
+        """
+        Captures the state_dict of the underlying worker datapipes via the consumer datapipe.
+        We only capture the worker datapipes's states and not the prefetching datapipe.
+        This is a PoC for now so there is no corresponding restoring action to make it properly checkpointable.
+        """
+        if self.num_workers == 0:
+            raise RuntimeError(
+                "If you would like to use `snapshot` with `MultiProcessingReadingService`, please use more than 0 workers."
+            )
+
+        self._pause()
+        result = self._worker_consumer_datapipe.state_dict()
+        self._resume()
+        return result
+
     def _pause(self):
         """
         Pauses DataPipes' activities such as prefetching, in order to collect state.


### PR DESCRIPTION
- I could not override `__getstate__` on the `QueueWrapper` and `_IterateQueueDataPipes` classes because those are used by torchdata internals

Questions:
- Should I make the test verify the state as well, by checking that snapshot._number_of_elements_yielded = i + prefetch_factor + 1 or 2 potentially?
- Do we have more chances of torchdata accepting the PR if we also snapshot the state of the prefetch worker? (does it even make sense to snapshot the state of that worker?)